### PR TITLE
Rails Stats Graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 work
+.settings
+.classpath
+.project

--- a/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsBuildAction.java
@@ -1,15 +1,18 @@
 package hudson.plugins.rubyMetrics.railsStats;
 
 import hudson.model.AbstractBuild;
-import hudson.model.HealthReport;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
 import hudson.plugins.rubyMetrics.railsStats.model.RailsStatsMetrics;
 import hudson.plugins.rubyMetrics.railsStats.model.RailsStatsResults;
 import hudson.util.ChartUtil;
-import hudson.util.DataSetBuilder;
 import hudson.util.ChartUtil.NumberOnlyBuildLabel;
+import hudson.util.DataSetBuilder;
 
+import java.io.IOException;
 import java.util.Map;
+
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 public class RailsStatsBuildAction extends AbstractRubyMetricsBuildAction {
 
@@ -32,15 +35,82 @@ public class RailsStatsBuildAction extends AbstractRubyMetricsBuildAction {
         return "railsStats";
     }
 
+    public void doGraphClasses(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        if (shouldGenerateGraph(req, rsp)) {
+            generateGraph(req, rsp, getDataSetBuilder(RailsStatsMetrics.CLASSES));
+        }
+    }
+
+    public void doGraphLoc(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        if (shouldGenerateGraph(req, rsp)) {
+            generateGraph(req, rsp, getDataSetBuilder(RailsStatsMetrics.LOC));
+        }
+    }
+
     @Override
     protected DataSetBuilder<String, NumberOnlyBuildLabel> getDataSetBuilder() {
+        return getDataSetBuilderRatios();
+    }
+
+    protected DataSetBuilder<String, NumberOnlyBuildLabel> getDataSetBuilder(
+            RailsStatsMetrics metric) {
+        DataSetBuilder<String, ChartUtil.NumberOnlyBuildLabel> dsb = new DataSetBuilder<String, ChartUtil.NumberOnlyBuildLabel>();
+
+        for (RailsStatsBuildAction a = this; a != null; a = a.getPreviousResult()) {
+            ChartUtil.NumberOnlyBuildLabel buildLabel = new ChartUtil.NumberOnlyBuildLabel(a.owner);
+
+            for (Map.Entry<String, Map<RailsStatsMetrics, Integer>> entry : a.results.getMetrics()
+                    .entrySet()) {
+                if (entry.getKey().equalsIgnoreCase("Total")) {
+                    continue;
+                }
+                dsb.add(entry.getValue().get(metric), entry.getKey(), buildLabel);
+            }
+        }
+
+        return dsb;
+    }
+
+    protected DataSetBuilder<String, NumberOnlyBuildLabel> getDataSetBuilderRatios() {
+        DataSetBuilder<String, ChartUtil.NumberOnlyBuildLabel> dsb = new DataSetBuilder<String, ChartUtil.NumberOnlyBuildLabel>();
+
+        for (RailsStatsBuildAction a = this; a != null; a = a.getPreviousResult()) {
+            ChartUtil.NumberOnlyBuildLabel buildLabel = new ChartUtil.NumberOnlyBuildLabel(a.owner);
+
+            int sumLoc = 0, sumLines = 0, sumTestLoc = 0, sumClasses = 0, sumMethods = 0;
+
+            for (Map.Entry<String, Map<RailsStatsMetrics, Integer>> entry : a.results.getMetrics()
+                    .entrySet()) {
+                String label = entry.getKey();
+                if (label.equalsIgnoreCase("Total")) {
+                    continue;
+                } else if (label.endsWith(" tests")) {
+                    sumTestLoc += entry.getValue().get(RailsStatsMetrics.LOC);
+                } else {
+                    sumLoc += entry.getValue().get(RailsStatsMetrics.LOC);
+                    sumLines += entry.getValue().get(RailsStatsMetrics.LINES);
+                    sumClasses += entry.getValue().get(RailsStatsMetrics.CLASSES);
+                    sumMethods += entry.getValue().get(RailsStatsMetrics.METHODS);
+                }
+            }
+
+            dsb.add(sumLoc / (double) sumMethods, RailsStatsMetrics.LOC_M.prettyPrint(), buildLabel);
+            dsb.add(sumMethods / (double) sumClasses, RailsStatsMetrics.M_C.prettyPrint(),
+                    buildLabel);
+            dsb.add(sumTestLoc / (double) sumLoc, "Test/Code", buildLabel);
+            dsb.add(sumLines / (double) sumLoc, "Lines/LOC", buildLabel);
+        }
+
+        return dsb;
+    }
+
+    protected DataSetBuilder<String, NumberOnlyBuildLabel> getDataSetBuilderOriginal() {
         DataSetBuilder<String, ChartUtil.NumberOnlyBuildLabel> dsb = new DataSetBuilder<String, ChartUtil.NumberOnlyBuildLabel>();
 
         for (RailsStatsBuildAction a = this; a != null; a = a.getPreviousResult()) {
             ChartUtil.NumberOnlyBuildLabel label = new ChartUtil.NumberOnlyBuildLabel(a.owner);
 
-            Map<RailsStatsMetrics, Integer> total = a.getResults().getTotal();
-            for (Map.Entry<RailsStatsMetrics, Integer> entry : total.entrySet()) {
+            for (Map.Entry<RailsStatsMetrics, Integer> entry : a.results.getTotal().entrySet()) {
                 dsb.add(entry.getValue(), entry.getKey().prettyPrint(), label);
             }
         }

--- a/src/main/resources/hudson/plugins/rubyMetrics/railsStats/RailsStatsBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/rubyMetrics/railsStats/RailsStatsBuildAction/index.jelly
@@ -8,9 +8,18 @@
 	            <h1>Rails stats report</h1>
 	            
 	            <j:if test="${it.previousResult != null}">
-	            	<img src="graph" width="500px" height="200px"/>
-	            </j:if>
-	            
+	            	<h2>Ratios</h2>
+                    <img src="graph" width="500px" height="200px"/>
+                    <br/>
+                    <h2>Classes</h2>
+                    <img src="graphClasses" width="500px" height="200px"/>
+                    <br/>
+                    <h2>Lines of Code</h2>
+                    <img src="graphLoc" width="500px" height="200px"/>
+                    <br/>
+                    <h2>Stats</h2>
+                </j:if>
+                
 	            <table class="report">
 	            	<thead>
 	            		<tr>


### PR DESCRIPTION
I worked a bit on the Rails Stats of the RubyMetrics plugin for Jenkins. As the current version limits the graphs to 100 units, it soon becomes useless for projects with more than 100 classes or even 100 LOC. So I removed this limit and split the stats graph into three different ones. Please find a screenshot at http://codez.ch/filez/rails_stats.pdf.
