### PR TITLE
also support current 'rake notes' output format 

### DIFF
--- a/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesParser.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesParser.java
@@ -36,7 +36,7 @@ public class RailsNotesParser {
             } else {
                 for (RailsNotesMetrics metric : RailsNotesMetrics.values()) {
                     // Match "  * [line#] [ANNOTATION]"
-                    Pattern metricPattern = Pattern.compile("^  \\* \\[[\\s\\d]+\\] \\[" + metric.toString() + "\\]");
+                    Pattern metricPattern = Pattern.compile("^  \\* \\[[\\s\\d]+\\] ?\\[" + metric.toString() + "\\]");
                     if (metricPattern.matcher(line).find()) {
                         response.addAnnotationFor(lastFile, metric);
                         break; // next line


### PR DESCRIPTION
Commit https://github.com/rails/rails/commit/9299bfdcd387253d83b645c205b8df477f2d0940
introduced a subtle change in the notes output, leaving out
the space between line-number and tag. This makes a slight update
of the RegEx necessary.
