### PR TITLE
enable it to work with older and LTS releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.576</version>
+        <version>1.532.3</version>
     </parent>
 
     <artifactId>rubyMetrics</artifactId>
@@ -64,6 +64,32 @@
         <url>https://github.com/jenkins/rubymetrics-plugin</url>
       <tag>HEAD</tag>
   </scm>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <compatibleSinceVersion>4.0</compatibleSinceVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
Shouldn't be any reason why a new NON LTS version is needed. 

see: https://github.com/jenkinsci/rubymetrics-plugin/commit/990f7a24dac005c3c40c155698a91f516bc154cd
