### PR TITLE
Add support for Pipeline jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.532.3</version>
+        <version>1.580</version>
     </parent>
 
     <artifactId>rubyMetrics</artifactId>
@@ -62,8 +62,8 @@
         <connection>scm:git:git://github.com/jenkinsci/rubymetrics-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/rubymetrics-plugin.git</developerConnection>
         <url>https://github.com/jenkins/rubymetrics-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <build>
         <plugins>

--- a/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsBuildAction.java
@@ -1,9 +1,6 @@
 package hudson.plugins.rubyMetrics;
 
-import hudson.model.AbstractBuild;
-import hudson.model.HealthReport;
-import hudson.model.HealthReportingAction;
-import hudson.model.Result;
+import hudson.model.*;
 import hudson.util.ChartUtil;
 import hudson.util.ColorPalette;
 import hudson.util.DataSetBuilder;
@@ -30,14 +27,14 @@ import java.util.Calendar;
 @SuppressWarnings("unchecked")
 public abstract class AbstractRubyMetricsBuildAction implements HealthReportingAction {
 
-    protected final AbstractBuild<?, ?> owner;
+    protected final Run<?, ?> owner;
 
-    protected AbstractRubyMetricsBuildAction(AbstractBuild<?, ?> owner) {
+    protected AbstractRubyMetricsBuildAction(Run<?, ?> owner) {
         this.owner = owner;
     }
 
     public <T extends AbstractRubyMetricsBuildAction> T getPreviousResult() {
-        AbstractBuild<?, ?> b = owner;
+        Run<?, ?> b = owner;
         while (true) {
             b = b.getPreviousBuild();
             if (b == null)
@@ -126,7 +123,7 @@ public abstract class AbstractRubyMetricsBuildAction implements HealthReportingA
         return chart;
     }
 
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getOwner() {
         return owner;
     }
 

--- a/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsBuildAction.java
@@ -5,6 +5,7 @@ import hudson.util.ChartUtil;
 import hudson.util.ColorPalette;
 import hudson.util.DataSetBuilder;
 import hudson.util.ShiftedCategoryAxis;
+import jenkins.tasks.SimpleBuildStep;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
@@ -25,7 +26,7 @@ import java.io.IOException;
 import java.util.Calendar;
 
 @SuppressWarnings("unchecked")
-public abstract class AbstractRubyMetricsBuildAction implements HealthReportingAction {
+public abstract class AbstractRubyMetricsBuildAction implements HealthReportingAction, SimpleBuildStep.LastBuildAction {
 
     protected final Run<?, ?> owner;
 

--- a/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsProjectAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsProjectAction.java
@@ -9,7 +9,8 @@ import java.io.IOException;
 @SuppressWarnings("unchecked")
 public abstract class AbstractRubyMetricsProjectAction<T extends AbstractRubyMetricsBuildAction> extends Actionable implements ProminentProjectAction {
 
-    protected final Job<?, ?> job;
+    protected Job<?, ?> job;
+    private transient AbstractProject<?, ?> project; // Retain backwards compatibility with old build records
 
     public AbstractRubyMetricsProjectAction(Job<?, ?> job) {
         this.job = job;
@@ -66,4 +67,10 @@ public abstract class AbstractRubyMetricsProjectAction<T extends AbstractRubyMet
         return null;
     }
 
+    private Object readResolve() {
+        if (job == null) {
+           job = project;
+        }
+        return this;
+    }
 }

--- a/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsProjectAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsProjectAction.java
@@ -9,14 +9,14 @@ import java.io.IOException;
 @SuppressWarnings("unchecked")
 public abstract class AbstractRubyMetricsProjectAction<T extends AbstractRubyMetricsBuildAction> extends Actionable implements ProminentProjectAction {
 
-    protected final AbstractProject<?, ?> project;
+    protected final Job<?, ?> job;
 
-    public AbstractRubyMetricsProjectAction(AbstractProject<?, ?> project) {
-        this.project = project;
+    public AbstractRubyMetricsProjectAction(Job<?, ?> job) {
+        this.job = job;
     }
 
-    public AbstractProject<?, ?> getProject() {
-        return project;
+    public Job<?, ?> getJob() {
+      return job;
     }
 
     public String getIconFileName() {
@@ -45,23 +45,23 @@ public abstract class AbstractRubyMetricsProjectAction<T extends AbstractRubyMet
     }
 
     public T getLastResult() {
-        for (AbstractBuild<?, ?> b = project.getLastStableBuild(); b != null; b = b.getPreviousNotFailedBuild()) {
-            if (b.getResult() == Result.FAILURE)
+        for (Run<?, ?> r = job.getLastStableBuild(); r != null; r = r.getPreviousNotFailedBuild()) {
+            if (r.getResult() == Result.FAILURE)
                 continue;
-            T r = b.getAction(getBuildActionClass());
-            if (r != null)
-                return r;
+            T result = r.getAction(getBuildActionClass());
+            if (result != null)
+                return result;
         }
         return null;
     }
 
     public Integer getLastResultBuild() {
-        for (AbstractBuild<?, ?> b = project.getLastStableBuild(); b != null; b = b.getPreviousNotFailedBuild()) {
-            if (b.getResult() == Result.FAILURE)
+        for (Run<?, ?> r = job.getLastStableBuild(); r != null; r = r.getPreviousNotFailedBuild()) {
+            if (r.getResult() == Result.FAILURE)
                 continue;
-            T r = b.getAction(getBuildActionClass());
-            if (r != null)
-                return b.getNumber();
+            T result = r.getAction(getBuildActionClass());
+            if (result != null)
+                return r.getNumber();
         }
         return null;
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/AbstractRubyMetricsPublisher.java
@@ -1,16 +1,14 @@
 package hudson.plugins.rubyMetrics;
 
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.Result;
+import hudson.model.*;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Recorder;
 
 public abstract class AbstractRubyMetricsPublisher extends Recorder {
 
-    protected boolean fail(AbstractBuild<?, ?> build, BuildListener listener, String message) {
+    protected boolean fail(Run<?, ?> run, TaskListener listener, String message) {
         listener.getLogger().println(message);
-        build.setResult(Result.FAILURE);
+        run.setResult(Result.FAILURE);
         return true;
     }
 

--- a/src/main/java/hudson/plugins/rubyMetrics/HtmlParser.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/HtmlParser.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics;
 
 import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 import org.htmlparser.Node;
 import org.htmlparser.Parser;
 import org.htmlparser.Text;
@@ -19,7 +20,7 @@ public abstract class HtmlParser {
     protected static final String CLASS_ATTR_NAME = "class";
 
     protected final File rootFilePath;
-    protected BuildListener listener;
+    protected TaskListener listener;
 
     public HtmlParser(File rootFilePath) {
         this.rootFilePath = rootFilePath;

--- a/src/main/java/hudson/plugins/rubyMetrics/flog/FlogBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/flog/FlogBuildAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics.flog;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Action;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
 import hudson.plugins.rubyMetrics.flog.model.FlogBuildResults;
 import hudson.util.ChartUtil;
@@ -11,6 +12,8 @@ import org.jfree.chart.plot.CategoryPlot;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Collection;
+import java.util.Collections;
 
 public class FlogBuildAction extends AbstractRubyMetricsBuildAction {
 
@@ -19,6 +22,10 @@ public class FlogBuildAction extends AbstractRubyMetricsBuildAction {
     public FlogBuildAction(AbstractBuild<?, ?> owner, FlogBuildResults results) {
         super(owner);
         this.results = results;
+    }
+
+    public Collection<? extends Action> getProjectActions() {
+      return Collections.singletonList(new FlogProjectAction(owner.getParent()));
     }
 
     @Override

--- a/src/main/java/hudson/plugins/rubyMetrics/flog/FlogProjectAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/flog/FlogProjectAction.java
@@ -1,10 +1,16 @@
 package hudson.plugins.rubyMetrics.flog;
 
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsProjectAction;
 
 public class FlogProjectAction<FlogBuildAction> extends AbstractRubyMetricsProjectAction {
 
+    public FlogProjectAction(Job<?, ?> job) {
+        super(job);
+    }
+
+    @Deprecated
     public FlogProjectAction(AbstractProject<?, ?> project) {
         super(project);
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/flog/FlogPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/flog/FlogPublisher.java
@@ -71,11 +71,6 @@ public class FlogPublisher extends AbstractRubyMetricsPublisher {
     }
 
     @Override
-    public Action getProjectAction(AbstractProject<?,?> project) {
-        return new FlogProjectAction<FlogBuildAction>(project);
-    }
-
-    @Override
     public BuildStepDescriptor<Publisher> getDescriptor() {
         return DESCRIPTOR;
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesBuildAction.java
@@ -1,5 +1,6 @@
 package hudson.plugins.rubyMetrics.railsNotes;
 
+import hudson.model.Action;
 import hudson.model.AbstractBuild;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
 import hudson.plugins.rubyMetrics.railsNotes.model.RailsNotesMetrics;
@@ -8,6 +9,8 @@ import hudson.util.ChartUtil;
 import hudson.util.ChartUtil.NumberOnlyBuildLabel;
 import hudson.util.DataSetBuilder;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 public class RailsNotesBuildAction extends AbstractRubyMetricsBuildAction {
@@ -16,6 +19,10 @@ public class RailsNotesBuildAction extends AbstractRubyMetricsBuildAction {
     public RailsNotesBuildAction(AbstractBuild<?, ?> owner, RailsNotesResults results) {
         super(owner);
         this.results = results;
+    }
+
+    public Collection<? extends Action> getProjectActions() {
+      return Collections.singletonList(new RailsNotesProjectAction(owner.getParent()));
     }
 
     public RailsNotesResults getResults() {

--- a/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesProjectAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesProjectAction.java
@@ -1,9 +1,15 @@
 package hudson.plugins.rubyMetrics.railsNotes;
 
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsProjectAction;
 
 public class RailsNotesProjectAction<RailsNotesBuildAction> extends AbstractRubyMetricsProjectAction {
+    public RailsNotesProjectAction(Job<?, ?> job) {
+        super(job);
+    }
+
+    @Deprecated
     public RailsNotesProjectAction(AbstractProject<?, ?> project) {
         super(project);
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsNotes/RailsNotesPublisher.java
@@ -34,11 +34,6 @@ public class RailsNotesPublisher extends AbstractRailsTaskPublisher {
         build.getActions().add(action);
     }
 
-    @Override
-    public Action getProjectAction(AbstractProject<?,?> project) {
-        return new RailsNotesProjectAction(project);
-    }
-
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 

--- a/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsBuildAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics.railsStats;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Action;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
 import hudson.plugins.rubyMetrics.railsStats.model.RailsStatsMetrics;
 import hudson.plugins.rubyMetrics.railsStats.model.RailsStatsResults;
@@ -11,6 +12,8 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 public class RailsStatsBuildAction extends AbstractRubyMetricsBuildAction {
@@ -20,6 +23,10 @@ public class RailsStatsBuildAction extends AbstractRubyMetricsBuildAction {
     public RailsStatsBuildAction(AbstractBuild<?, ?> owner, RailsStatsResults results) {
         super(owner);
         this.results = results;
+    }
+
+    public Collection<? extends Action> getProjectActions() {
+      return Collections.singletonList(new RailsStatsProjectAction(owner.getParent()));
     }
 
     public RailsStatsResults getResults() {

--- a/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsProjectAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsProjectAction.java
@@ -1,10 +1,16 @@
 package hudson.plugins.rubyMetrics.railsStats;
 
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsProjectAction;
 
 public class RailsStatsProjectAction<RailsStatsBuildAction> extends AbstractRubyMetricsProjectAction {
 
+    public RailsStatsProjectAction(Job<?, ?> job) {
+        super(job);
+    }
+
+    @Deprecated
     public RailsStatsProjectAction(AbstractProject<?, ?> project) {
         super(project);
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/railsStats/RailsStatsPublisher.java
@@ -36,11 +36,6 @@ public class RailsStatsPublisher extends AbstractRailsTaskPublisher {
         build.getActions().add(action);
     }
 
-    @Override
-    public Action getProjectAction(AbstractProject<?,?> project) {
-        return new RailsStatsProjectAction(project);
-    }
-
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 

--- a/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovBuildAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics.rcov;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Action;
 import hudson.model.HealthReport;
 import hudson.model.Run;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
@@ -11,6 +12,8 @@ import hudson.util.DataSetBuilder;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class RcovBuildAction extends AbstractRubyMetricsBuildAction {
@@ -22,6 +25,10 @@ public class RcovBuildAction extends AbstractRubyMetricsBuildAction {
         super(owner);
         this.results = results;
         this.targets = targets;
+    }
+
+    public Collection<? extends Action> getProjectActions() {
+      return Collections.singletonList(new RcovProjectAction(owner.getParent()));
     }
 
     public HealthReport getBuildHealth() {

--- a/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovBuildAction.java
@@ -2,6 +2,7 @@ package hudson.plugins.rubyMetrics.rcov;
 
 import hudson.model.AbstractBuild;
 import hudson.model.HealthReport;
+import hudson.model.Run;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
 import hudson.plugins.rubyMetrics.rcov.model.*;
 import hudson.util.ChartUtil;
@@ -17,7 +18,7 @@ public class RcovBuildAction extends AbstractRubyMetricsBuildAction {
     private final RcovResult results;
     private final List<MetricTarget> targets;
 
-    public RcovBuildAction(AbstractBuild<?, ?> owner, RcovResult results, List<MetricTarget> targets) {
+    public RcovBuildAction(Run<?, ?> owner, RcovResult results, List<MetricTarget> targets) {
         super(owner);
         this.results = results;
         this.targets = targets;

--- a/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovProjectAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovProjectAction.java
@@ -1,10 +1,16 @@
 package hudson.plugins.rubyMetrics.rcov;
 
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsProjectAction;
 
 public class RcovProjectAction<RcovBuildAction> extends AbstractRubyMetricsProjectAction {
 
+    public RcovProjectAction(Job<?, ?> job) {
+        super(job);
+    }
+
+    @Deprecated
     public RcovProjectAction(AbstractProject<?, ?> project) {
         super(project);
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovPublisher.java
@@ -92,6 +92,7 @@ public class RcovPublisher extends HtmlPublisher implements SimpleBuildStep {
         return targets;
     }
 
+    @DataBoundSetter
     public void setTargets(List<MetricTarget> targets) {
         this.targets = targets;
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovPublisher.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics.rcov;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.plugins.rubyMetrics.HtmlPublisher;
@@ -9,11 +10,14 @@ import hudson.plugins.rubyMetrics.rcov.model.RcovResult;
 import hudson.plugins.rubyMetrics.rcov.model.Targets;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -27,9 +31,12 @@ import java.util.List;
  *
  */
 @SuppressWarnings({"unchecked", "serial"})
-public class RcovPublisher extends HtmlPublisher {
+public class RcovPublisher extends HtmlPublisher implements SimpleBuildStep {
 
-    private List<MetricTarget> targets;
+    private List<MetricTarget> targets = new ArrayList<MetricTarget>(){{
+        add(new MetricTarget(Targets.TOTAL_COVERAGE, 80, null, null));
+        add(new MetricTarget(Targets.CODE_COVERAGE, 80, null, null));
+    }};
 
     @DataBoundConstructor
     public RcovPublisher(String reportDir) {
@@ -40,27 +47,26 @@ public class RcovPublisher extends HtmlPublisher {
      * {@inheritDoc}
      */
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+                        @Nonnull TaskListener listener) throws InterruptedException, IOException {
         final RcovFilenameFilter indexFilter = new RcovFilenameFilter();
-        prepareMetricsReportBeforeParse(build, listener, indexFilter, DESCRIPTOR.getToolShortName());
-        if (build.getResult() == Result.FAILURE) {
-            return false;
+        prepareMetricsReportBeforeParse(run, workspace, listener, indexFilter, DESCRIPTOR.getToolShortName());
+        if (run.getResult() == Result.FAILURE) {
+            return;
         }
 
-        RcovParser parser = new RcovParser(build.getRootDir());
-        RcovResult results = parser.parse(getCoverageFiles(build, indexFilter)[0]);
+        RcovParser parser = new RcovParser(run.getRootDir());
+        RcovResult results = parser.parse(getCoverageFiles(run, indexFilter)[0]);
 
-        RcovBuildAction action = new RcovBuildAction(build, results, targets);
-        build.getActions().add(action);
+        RcovBuildAction action = new RcovBuildAction(run, results, targets);
+        run.getActions().add(action);
 
         if (failMetrics(results, listener)) {
-            build.setResult(Result.UNSTABLE);
+            run.setResult(Result.UNSTABLE);
         }
-
-        return true;
     }
 
-    private boolean failMetrics(RcovResult results, BuildListener listener) {
+    private boolean failMetrics(RcovResult results, TaskListener listener) {
         float initRatio = 0;
         float resultRatio = 0;
         for (MetricTarget target : targets) {

--- a/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/rcov/RcovPublisher.java
@@ -82,12 +82,6 @@ public class RcovPublisher extends HtmlPublisher implements SimpleBuildStep {
         return false;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Action getProjectAction(final AbstractProject<?, ?> project) {
-        return new RcovProjectAction(project);
-    }
-
     public List<MetricTarget> getTargets() {
         return targets;
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/rcov/model/RcovFileDetail.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/rcov/model/RcovFileDetail.java
@@ -2,6 +2,7 @@ package hudson.plugins.rubyMetrics.rcov.model;
 
 import hudson.model.AbstractBuild;
 import hudson.model.ModelObject;
+import hudson.model.Run;
 import hudson.plugins.rubyMetrics.rcov.RcovParser;
 import org.htmlparser.util.ParserException;
 
@@ -17,10 +18,10 @@ public class RcovFileDetail implements ModelObject, Serializable  {
 
     private static final Logger LOGGER = Logger.getLogger(RcovFileDetail.class.getName());
 
-    private final AbstractBuild<?, ?> owner;
+    private final Run<?, ?> owner;
     private final RcovFileResult result;
 
-    public RcovFileDetail(final AbstractBuild<?, ?> owner, final RcovFileResult result) {
+    public RcovFileDetail(final Run<?, ?> owner, final RcovFileResult result) {
         this.owner = owner;
         this.result = result;
     }
@@ -29,7 +30,7 @@ public class RcovFileDetail implements ModelObject, Serializable  {
         return serialVersionUID;
     }
 
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getOwner() {
         return owner;
     }
 

--- a/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroBuildAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics.saikuro;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
 import hudson.plugins.rubyMetrics.saikuro.model.SaikuroFileDetail;
 import hudson.plugins.rubyMetrics.saikuro.model.SaikuroFileResult;
@@ -15,7 +16,7 @@ public class SaikuroBuildAction extends AbstractRubyMetricsBuildAction{
 
     private SaikuroResult results;
 
-    public SaikuroBuildAction(AbstractBuild<?, ?> owner, SaikuroResult results) {
+    public SaikuroBuildAction(Run<?, ?> owner, SaikuroResult results) {
         super(owner);
         this.results = results;
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroBuildAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroBuildAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics.saikuro;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Action;
 import hudson.model.Run;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsBuildAction;
 import hudson.plugins.rubyMetrics.saikuro.model.SaikuroFileDetail;
@@ -12,6 +13,9 @@ import hudson.util.DataSetBuilder;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class SaikuroBuildAction extends AbstractRubyMetricsBuildAction{
 
     private SaikuroResult results;
@@ -19,6 +23,10 @@ public class SaikuroBuildAction extends AbstractRubyMetricsBuildAction{
     public SaikuroBuildAction(Run<?, ?> owner, SaikuroResult results) {
         super(owner);
         this.results = results;
+    }
+
+    public Collection<? extends Action> getProjectActions() {
+      return Collections.singletonList(new SaikuroProjectAction(owner.getParent()));
     }
 
     @Override

--- a/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroParser.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroParser.java
@@ -1,6 +1,7 @@
 package hudson.plugins.rubyMetrics.saikuro;
 
 import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 import hudson.plugins.rubyMetrics.HtmlParser;
 import hudson.plugins.rubyMetrics.saikuro.model.SaikuroFileResult;
 import hudson.plugins.rubyMetrics.saikuro.model.SaikuroResult;
@@ -20,7 +21,7 @@ import java.io.InputStream;
 
 public class SaikuroParser extends HtmlParser {
 
-    public SaikuroParser(File rootFilePath, BuildListener listener) {
+    public SaikuroParser(File rootFilePath, TaskListener listener) {
         super(rootFilePath);
         this.listener = listener;
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroProjectAction.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroProjectAction.java
@@ -1,10 +1,16 @@
 package hudson.plugins.rubyMetrics.saikuro;
 
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.plugins.rubyMetrics.AbstractRubyMetricsProjectAction;
 
 public class SaikuroProjectAction<SaikuroBuildAction> extends AbstractRubyMetricsProjectAction {
 
+    public SaikuroProjectAction(Job<?, ?> job) {
+        super(job);
+    }
+
+    @Deprecated
     public SaikuroProjectAction(AbstractProject<?, ?> project) {
         super(project);
     }

--- a/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroPublisher.java
@@ -49,11 +49,6 @@ public class SaikuroPublisher extends HtmlPublisher implements SimpleBuildStep {
         }
     }
 
-    @Override
-    public Action getProjectAction(final AbstractProject<?, ?> project) {
-        return new SaikuroProjectAction(project);
-    }
-
     //@Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 

--- a/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroPublisher.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/saikuro/SaikuroPublisher.java
@@ -1,20 +1,23 @@
 package hudson.plugins.rubyMetrics.saikuro;
 
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.plugins.rubyMetrics.HtmlPublisher;
 import hudson.plugins.rubyMetrics.saikuro.model.SaikuroResult;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 
-public class SaikuroPublisher extends HtmlPublisher {
+public class SaikuroPublisher extends HtmlPublisher implements SimpleBuildStep {
 
     @DataBoundConstructor
     public SaikuroPublisher(String reportDir) {
@@ -25,20 +28,19 @@ public class SaikuroPublisher extends HtmlPublisher {
      * {@inheritDoc}
      */
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+                        @Nonnull TaskListener listener) throws InterruptedException, IOException {
         final SaikuroFilenameFilter indexFilter = new SaikuroFilenameFilter();
-        prepareMetricsReportBeforeParse(build, listener, indexFilter, DESCRIPTOR.getToolShortName());
-        if (build.getResult() == Result.FAILURE) {
-            return false;
+        prepareMetricsReportBeforeParse(run, workspace, listener, indexFilter, DESCRIPTOR.getToolShortName());
+        if (run.getResult() == Result.FAILURE) {
+            return;
         }
 
-        SaikuroParser parser = new SaikuroParser(build.getRootDir(), listener);
-        SaikuroResult results = parser.parse(getCoverageFiles(build, indexFilter)[0]);
+        SaikuroParser parser = new SaikuroParser(run.getRootDir(), listener);
+        SaikuroResult results = parser.parse(getCoverageFiles(run, indexFilter)[0]);
 
-        SaikuroBuildAction action = new SaikuroBuildAction(build, results);
-        build.getActions().add(action);
-
-        return true;
+        SaikuroBuildAction action = new SaikuroBuildAction(run, results);
+        run.getActions().add(action);
     }
 
     private static class SaikuroFilenameFilter implements FilenameFilter {

--- a/src/main/java/hudson/plugins/rubyMetrics/saikuro/model/SaikuroFileDetail.java
+++ b/src/main/java/hudson/plugins/rubyMetrics/saikuro/model/SaikuroFileDetail.java
@@ -2,20 +2,21 @@ package hudson.plugins.rubyMetrics.saikuro.model;
 
 import hudson.model.AbstractBuild;
 import hudson.model.ModelObject;
+import hudson.model.Run;
 
 import java.io.Serializable;
 
 public class SaikuroFileDetail implements ModelObject, Serializable  {
 
-    private final AbstractBuild<?, ?> owner;
+    private final Run<?, ?> owner;
     private final SaikuroFileResult result;
 
-    public SaikuroFileDetail(final AbstractBuild<?, ?> owner, final SaikuroFileResult result) {
+    public SaikuroFileDetail(final Run<?, ?> owner, final SaikuroFileResult result) {
         this.owner = owner;
         this.result = result;
     }
 
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getOwner() {
         return owner;
     }
 

--- a/src/main/resources/hudson/plugins/rubyMetrics/flog/FlogProjectAction/nodata.jelly
+++ b/src/main/resources/hudson/plugins/rubyMetrics/flog/FlogProjectAction/nodata.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
         >
     <l:layout css="/plugin/rubyMetrics/css/style.css">
-        <st:include it="${it.project}" page="sidepanel.jelly"/>
+        <st:include it="${it.job}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>No valid coverage data available</h1>
             <p>

--- a/src/main/resources/hudson/plugins/rubyMetrics/railsNotes/RailsNotesProjectAction/nodata.jelly
+++ b/src/main/resources/hudson/plugins/rubyMetrics/railsNotes/RailsNotesProjectAction/nodata.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
         >
     <l:layout css="/plugin/rubyMetrics/css/style.css">
-        <st:include it="${it.project}" page="sidepanel.jelly"/>
+        <st:include it="${it.job}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>No annotation data available</h1>
         </l:main-panel>

--- a/src/main/resources/hudson/plugins/rubyMetrics/railsStats/RailsStatsProjectAction/nodata.jelly
+++ b/src/main/resources/hudson/plugins/rubyMetrics/railsStats/RailsStatsProjectAction/nodata.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
         >
     <l:layout css="/plugin/rubyMetrics/css/style.css">
-        <st:include it="${it.project}" page="sidepanel.jelly"/>
+        <st:include it="${it.job}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>No valid coverage data available</h1>
             <p>

--- a/src/main/resources/hudson/plugins/rubyMetrics/rcov/RcovProjectAction/nodata.jelly
+++ b/src/main/resources/hudson/plugins/rubyMetrics/rcov/RcovProjectAction/nodata.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
         >
     <l:layout css="/plugin/rubyMetrics/css/style.css">
-        <st:include it="${it.project}" page="sidepanel.jelly"/>
+        <st:include it="${it.job}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>No valid coverage data available</h1>
             <p>

--- a/src/main/resources/hudson/plugins/rubyMetrics/saikuro/SaikuroProjectAction/nodata.jelly
+++ b/src/main/resources/hudson/plugins/rubyMetrics/saikuro/SaikuroProjectAction/nodata.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
         >
     <l:layout css="/plugin/rubyMetrics/css/style.css">
-        <st:include it="${it.project}" page="sidepanel.jelly"/>
+        <st:include it="${it.job}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>No valid data available</h1>
             <p>


### PR DESCRIPTION
This PR updates this plugin to work correctly with pipeline jobs.

The main change is to change references to `AbstractProject`, `AbstractBuild`, and `BuildListener` to refer to `Job`, `Run`, and `TaskListener` respectively. Another change is to implement `SimpleBuildStep.LastBuildAction` to allow build actions to contribute actions to a project.

One thing I did not do was to make this plugin actually depend on the Pipeline API, so in order to use the publishers, you'll need to use the `step` metastep. Here's an example for `RcovPublisher`:

```groovy
step([
    $class: 'RcovPublisher',
    reportDir: "coverage/rcov",
    targets: [
        [metric: "CODE_COVERAGE", healthy: 75, unhealthy: 50, unstable: 30]
    ]
])
```

Many thanks to @SuperTux88 for starting this work in https://github.com/jenkinsci/rubymetrics-plugin/commit/61f5f2ad69c284e89e7d04660fb6365ddc780eb3 and to @cprice404 for his helpful guide to refactoring Jenkins plugins to be pipeline-compatible: https://jenkins.io/blog/2016/05/25/update-plugin-for-pipeline/